### PR TITLE
[ refactor ] make freshness annotation runtime irrelevant

### DIFF
--- a/src/Collie.idr
+++ b/src/Collie.idr
@@ -27,14 +27,14 @@ import public System
 
 public export
 castGen : (name : a -> String) -> (sx : SnocList a) ->
-  {auto fresh : Fresh {neq = (#) `on` Builtin.fst}
+  {auto 0 fresh : Fresh {neq = (#) `on` Builtin.fst}
                   (map (\u => (name u, u)) sx) } ->
   Fields a
 castGen name sx = cast (map (\u => (name u, u)) sx)
 
 public export
 MkCommands : (sx : SnocList Command) ->
-  {auto fresh : Fresh {neq = (#) `on` Builtin.fst}
+  {auto 0 fresh : Fresh {neq = (#) `on` Builtin.fst}
                   (map (\u => (u.name, u)) sx) } ->
   Fields Command
 MkCommands = castGen name

--- a/src/Data/List/Fresh/Quantifiers.idr
+++ b/src/Data/List/Fresh/Quantifiers.idr
@@ -6,9 +6,9 @@ import Data.DPair
 namespace Any
   public export
   data Any : (0 p : a -> Type) -> FreshList a neq -> Type where
-    Here : {0 xs : FreshList a neq} -> (val : p x) -> {auto fresh : x # xs} ->
+    Here : {0 xs : FreshList a neq} -> (val : p x) -> {auto 0 fresh : x # xs} ->
       Any p ((x :: xs) {fresh})
-    There : {0 xs : FreshList a neq} -> (pos : Any p xs) -> {auto fresh : x # xs} ->
+    There : {0 xs : FreshList a neq} -> (pos : Any p xs) -> {auto 0 fresh : x # xs} ->
       Any p ((x :: xs) {fresh})
 
 export
@@ -19,11 +19,12 @@ namespace All
   public export
   data All : (0 p : a -> Type) -> FreshList a neq -> Type where
     Nil : All p Nil
-    (::) : {0 xs : FreshList a neq} -> (val : p x) -> {auto fresh : x # xs} -> (vals : All p xs) ->
+    (::) : {0 xs : FreshList a neq} -> (val : p x) ->
+           {auto 0 fresh : x # xs} -> (vals : All p xs) ->
       All p ((x :: xs) {fresh})
 
 public export
-lookupWithProof : {xs : FreshList a neq} -> (pos : Any p xs) -> (x : a **  p x)
+lookupWithProof : {xs : FreshList a neq} -> (pos : Any p xs) -> (x : a ** p x)
 lookupWithProof (Here  val) = (_ ** val)
 lookupWithProof (There pos) = lookupWithProof pos
 
@@ -64,7 +65,7 @@ any decide (x :: xs) = case decide x of
   Yes prf   => Yes $ Here prf
   No not_x  => case any decide xs of
                  Yes prf    => Yes (There prf)
-                 No  not_xs => No \case
+                 No  not_xs => No $ \case
                    Here val  => not_x val
                    There pos => not_xs pos
 

--- a/src/Data/Record/Ordered/SmartConstructors.idr
+++ b/src/Data/Record/Ordered/SmartConstructors.idr
@@ -14,7 +14,7 @@ public export
 (::) : {x : a} -> {flds : Fields a} ->
   (namearg : (String, f x)) ->
    (rec : Record f flds) ->
-  {auto fresh : IsYes (decideFreshness (fst namearg, x) (\y => (fst namearg #? (fst y))) flds)} ->
+  {auto 0 fresh : IsYes (decideFreshness (fst namearg, x) (\y => (fst namearg #? (fst y))) flds)} ->
   Record f (((fst namearg, x) :: flds) {fresh = toWitness fresh})
 (name, arg) :: rec = MkRecord ((arg :: rec.content) {fresh = toWitness fresh})
 

--- a/src/Decidable/Decidable/Extra.idr
+++ b/src/Decidable/Decidable/Extra.idr
@@ -3,5 +3,5 @@ module Decidable.Decidable.Extra
 import public Decidable.Decidable
 
 public export
-toWitness : {prf : Dec a} -> IsYes prf -> a
+toWitness : {prf : Dec a} -> (0 _ : IsYes prf) -> a
 toWitness {prf = Yes prf} x = prf


### PR DESCRIPTION
These make the data structure quadratic instead of linear so we get
rid of them. This should enable idris to detect that fresh lists can
be represented as lists at runtime.