### PR TITLE
[ new ] direct dispatching of handlers using fromString

### DIFF
--- a/tests/examples/deeply-nested/DeeplyNested.idr
+++ b/tests/examples/deeply-nested/DeeplyNested.idr
@@ -4,6 +4,7 @@ module DeeplyNested
 
 import Collie
 import Data.List.Quantifiers
+import Data.List
 
 %default total
 
@@ -50,5 +51,17 @@ handle
                   ]
     ]
 
+
+handle' : Turns ~:> IO ()
+handle' "           " args = let files = fromMaybe [] args.arguments in
+                             putStrLn "Received the files: \{show files}"
+handle' "right      " args = putStrLn "Took a right turn"
+handle' "right left " args = putStrLn "Back to the start (rl)"
+handle' "right right" args = putStrLn "Half turn, rightwise"
+handle' "left       " args = putStrLn "Took a left turn"
+handle' "left  left " args = putStrLn "Half turn, leftwise"
+handle' "left  right" args = putStrLn "Back to the start (lr)"
+
 main : IO ()
-main = Turns .handleWith handle
+main = do -- Turns .handleWith handle
+          Turns .handleWith' handle'


### PR DESCRIPTION
Pros:

1. A function `handle : cmd ~:> IO ()` rather than a """record"""
2. Coverage checking works

Cons:

1. It's hijacking the `fromString` mechanism
2. It'd be nicer to have `handler ["sub1", "sub2"]` rather than `handler "sub1   sub2"`